### PR TITLE
Sleep quietly

### DIFF
--- a/src/hadoop_util/transfer.clj
+++ b/src/hadoop_util/transfer.clj
@@ -108,7 +108,6 @@
                os (BufferedOutputStream. (FileOutputStream. local-path))]
      (loop [sleep-ms (sleep-interval throttle)]
        (when (pos? sleep-ms)
-         (prn "Sleep: " sleep-ms)
          (Thread/sleep sleep-ms))
        (let [amt (.read is buffer)]
          (when (pos? amt)


### PR DESCRIPTION
This was a bit too verbose.
Also, since there is no synchronization when running in multiple threads prints things like `"Sleep: " ""SSlleep: " eep: " 221.23027379949224221.23027379949224`

P.S.: A PR to fix elephantdb to use this properly again is probably following later
